### PR TITLE
Implement session and document management

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
-    "pg": "^8.16.0"
+    "pg": "^8.16.0",
+    "openai": "^4.0.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,58 @@ model User {
   password  String
   role      Role    @default(CLIENT)
   createdAt DateTime @default(now())
+  sessions  UserSession[]
+}
+
+model UserSession {
+  id           String   @id @default(uuid())
+  userId       Int
+  sessionToken String   @unique
+  crmToken     String
+  createdAt    DateTime @default(now())
+  expiresAt    DateTime
+  user         User     @relation(fields: [userId], references: [id])
+}
+
+model DocumentFile {
+  id            Int      @id @default(autoincrement())
+  filename      String
+  crmDocumentId String?
+  createdAt     DateTime @default(now())
+  estados       DocumentoEstado[]
+}
+
+model DocumentoEstado {
+  id               Int      @id @default(autoincrement())
+  documentId       Int
+  estado           String
+  observacionAI    String?
+  observacionAbogado String?
+  updatedAt        DateTime @updatedAt
+  document         DocumentFile @relation(fields: [documentId], references: [id])
+}
+
+model NotificacionCliente {
+  id        Int      @id @default(autoincrement())
+  clienteId Int
+  mensaje   String
+  leido     Boolean  @default(false)
+  createdAt DateTime @default(now())
+}
+
+model ExpedientePredefinido {
+  id          Int   @id @default(autoincrement())
+  nombre      String
+  descripcion String?
+  tiposDocumento Json
+}
+
+model RegistroModificacion {
+  id        Int      @id @default(autoincrement())
+  documentId Int
+  usuarioId Int
+  mensaje   String
+  fecha     DateTime @default(now())
 }
 
 enum Role {

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
 import routes from './routes';
+import { ipAudit } from './middlewares/ipAudit.middleware';
 
 const app = express();
 
 app.use(cors());
 app.use(morgan('dev'));
+app.use(ipAudit);
 app.use(express.json());
 app.use('/api', routes);
 

--- a/src/controllers/documento.controller.ts
+++ b/src/controllers/documento.controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { crmPost, crmGet } from '../services/crm.service';
+import { validateDocument } from '../services/openai.service';
+import prisma from '../utils/prisma';
+
+export const uploadDocumento = async (req: Request, res: Response) => {
+  try {
+    const file = req.body.filePath as string; // Ruta temporal del archivo
+    const crmResponse = await crmPost('/documento/upload', req.crmToken!, {
+      file,
+    });
+    const validation = await validateDocument(file);
+
+    const record = await prisma.documentFile.create({
+      data: {
+        filename: file,
+        crmDocumentId: crmResponse.id,
+      },
+    });
+
+    await prisma.documentoEstado.create({
+      data: {
+        documentId: record.id,
+        estado: validation ? 'Pre Aprobado' : 'Pre Denegado',
+        observacionAI: validation,
+      },
+    });
+
+    res.json(record);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al subir documento' });
+  }
+};
+
+export const descargarDocumento = async (req: Request, res: Response) => {
+  try {
+    const { documentId } = req.body;
+    const documento = await prisma.documentFile.findUnique({
+      where: { id: documentId },
+    });
+    if (!documento) return res.status(404).json({ error: 'No encontrado' });
+    const data = await crmGet(`/documento/${documento.crmDocumentId}`, req.crmToken!);
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al descargar' });
+  }
+};

--- a/src/controllers/expediente.controller.ts
+++ b/src/controllers/expediente.controller.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import { crmGet } from '../services/crm.service';
+
+export const getExpedientes = async (req: Request, res: Response) => {
+  try {
+    const data = await crmGet('/expedientes', req.crmToken!);
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al obtener expedientes' });
+  }
+};
+
+export const getDocumentos = async (req: Request, res: Response) => {
+  const { expedienteId } = req.params;
+  try {
+    const data = await crmGet(`/documentos/${expedienteId}`, req.crmToken!);
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al obtener documentos' });
+  }
+};

--- a/src/controllers/expedientePredefinido.controller.ts
+++ b/src/controllers/expedientePredefinido.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import prisma from '../utils/prisma';
+
+export const createExpedientePredefinido = async (req: Request, res: Response) => {
+  const data = await prisma.expedientePredefinido.create({ data: req.body });
+  res.json(data);
+};
+
+export const listExpedientePredefinido = async (_req: Request, res: Response) => {
+  const data = await prisma.expedientePredefinido.findMany();
+  res.json(data);
+};
+
+export const updateExpedientePredefinido = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const data = await prisma.expedientePredefinido.update({ where: { id: parseInt(id, 10) }, data: req.body });
+  res.json(data);
+};
+
+export const deleteExpedientePredefinido = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  await prisma.expedientePredefinido.delete({ where: { id: parseInt(id, 10) } });
+  res.status(204).end();
+};

--- a/src/controllers/notificacion.controller.ts
+++ b/src/controllers/notificacion.controller.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+import prisma from '../utils/prisma';
+
+export const getNotificaciones = async (req: Request, res: Response) => {
+  const { clienteId } = req.params;
+  const notificaciones = await prisma.notificacionCliente.findMany({
+    where: { clienteId: parseInt(clienteId, 10) },
+    orderBy: { createdAt: 'desc' },
+  });
+  res.json(notificaciones);
+};

--- a/src/middlewares/ipAudit.middleware.ts
+++ b/src/middlewares/ipAudit.middleware.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const ipAudit = (req: Request, _res: Response, next: NextFunction) => {
+  const ip = req.ip;
+  console.log(`IP ${ip} accessing ${req.originalUrl}`);
+  next();
+};

--- a/src/middlewares/role.middleware.ts
+++ b/src/middlewares/role.middleware.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../utils/prisma';
+import { Role } from '@prisma/client';
+
+export const attachRole = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      return res.status(401).json({ error: 'Usuario no identificado' });
+    }
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      return res.status(401).json({ error: 'Usuario no encontrado' });
+    }
+    req.userRole = user.role;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const requireRole = (roles: Role[]) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const role = req.userRole;
+    if (!role || !roles.includes(role)) {
+      return res.status(403).json({ error: 'Permiso denegado' });
+    }
+    next();
+  };
+};

--- a/src/middlewares/session.middleware.ts
+++ b/src/middlewares/session.middleware.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../utils/prisma';
+
+export const requireSession = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const token = req.headers['x-session-token'];
+    if (!token || typeof token !== 'string') {
+      return res.status(401).json({ error: 'Token de sesión requerido' });
+    }
+
+    const session = await prisma.userSession.findUnique({
+      where: { sessionToken: token },
+    });
+
+    if (!session) {
+      return res.status(401).json({ error: 'Sesión inválida' });
+    }
+
+    req.crmToken = session.crmToken;
+    req.userId = session.userId;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/expediente.routes.ts
+++ b/src/routes/expediente.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { getExpedientes, getDocumentos } from '../controllers/expediente.controller';
+import { uploadDocumento, descargarDocumento } from '../controllers/documento.controller';
+import { getNotificaciones } from '../controllers/notificacion.controller';
+import { requireSession } from '../middlewares/session.middleware';
+import { attachRole, requireRole } from '../middlewares/role.middleware';
+import { Role } from '@prisma/client';
+
+const router = Router();
+
+router.use(requireSession, attachRole);
+
+router.get('/expedientes', getExpedientes);
+router.get('/documentos/:expedienteId', getDocumentos);
+router.post('/documento/upload', requireRole([Role.ABOGADO, Role.ASESOR, Role.SUPERADMIN]), uploadDocumento);
+router.post('/documento/descargar', descargarDocumento);
+router.get('/notificaciones/:clienteId', getNotificaciones);
+
+export default router;

--- a/src/routes/expedientePredefinido.routes.ts
+++ b/src/routes/expedientePredefinido.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import {
+  createExpedientePredefinido,
+  listExpedientePredefinido,
+  updateExpedientePredefinido,
+  deleteExpedientePredefinido,
+} from '../controllers/expedientePredefinido.controller';
+import { requireSession } from '../middlewares/session.middleware';
+import { attachRole, requireRole } from '../middlewares/role.middleware';
+import { Role } from '@prisma/client';
+
+const router = Router();
+
+router.use(requireSession, attachRole, requireRole([Role.SUPERADMIN]));
+
+router.post('/', createExpedientePredefinido);
+router.get('/', listExpedientePredefinido);
+router.put('/:id', updateExpedientePredefinido);
+router.delete('/:id', deleteExpedientePredefinido);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
-import migrateRoutes from './migrate.routes'; // 👈 Importamos
+import migrateRoutes from './migrate.routes';
+import expedienteRoutes from './expediente.routes';
+import expedientePredefinidoRoutes from './expedientePredefinido.routes';
 
 const router = Router();
 
-router.use('/', migrateRoutes); // 👈 Montamos la ruta directamente
+router.use('/', migrateRoutes);
+router.use('/crm', expedienteRoutes);
+router.use('/predefinidos', expedientePredefinidoRoutes);
 
 export default router;
-
-

--- a/src/services/crm.service.ts
+++ b/src/services/crm.service.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const CRM_URL = process.env.CRM_URL || '';
+
+export const crmGet = async (path: string, token: string) => {
+  const { data } = await axios.get(`${CRM_URL}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
+
+export const crmPost = async (path: string, token: string, body: any) => {
+  const { data } = await axios.post(`${CRM_URL}${path}`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};

--- a/src/services/openai.service.ts
+++ b/src/services/openai.service.ts
@@ -1,0 +1,14 @@
+import { Configuration, OpenAIApi } from 'openai';
+import fs from 'fs';
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+export const validateDocument = async (path: string): Promise<string> => {
+  const file = fs.readFileSync(path);
+  const { data } = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: 'Analiza el documento' }],
+  });
+  return data.choices[0].message?.content || '';
+};

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,13 @@
+import { Role } from '@prisma/client';
+
+declare global {
+  namespace Express {
+    interface Request {
+      crmToken?: string;
+      userId?: number;
+      userRole?: Role;
+    }
+  }
+}
+
+export {};

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add Prisma client helper
- implement session validation and role middlewares
- secure IP audit middleware
- add services for CRM and OpenAI
- create controllers for expedientes, documents, notifications, and predefined templates
- expose new protected routes
- extend Prisma schema with sessions, documents, notifications and more
- include Express request typings

## Testing
- `npm run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6848036016808327a6d0c9acb257622b