### PR TITLE
Update document upload flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,11 +27,13 @@ model UserSession {
 }
 
 model DocumentFile {
-  id            Int      @id @default(autoincrement())
-  filename      String
-  crmDocumentId String?
-  createdAt     DateTime @default(now())
-  estados       DocumentoEstado[]
+  id                 Int      @id @default(autoincrement())
+  documentTemplateId Int
+  expedientId        Int
+  crmDocumentId      String
+  fileName           String
+  createdAt          DateTime @default(now())
+  estados            DocumentoEstado[]
 }
 
 model DocumentoEstado {

--- a/src/routes/expediente.routes.ts
+++ b/src/routes/expediente.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { getExpedientes, getDocumentos } from '../controllers/expediente.controller';
 import { uploadDocumento, descargarDocumento } from '../controllers/documento.controller';
+import multer from 'multer';
 import { getNotificaciones } from '../controllers/notificacion.controller';
 import { requireSession } from '../middlewares/session.middleware';
 import { attachRole, requireRole } from '../middlewares/role.middleware';
@@ -8,11 +9,18 @@ import { Role } from '@prisma/client';
 
 const router = Router();
 
+const upload = multer({ storage: multer.memoryStorage() });
+
 router.use(requireSession, attachRole);
 
 router.get('/expedientes', getExpedientes);
 router.get('/documentos/:expedienteId', getDocumentos);
-router.post('/documento/upload', requireRole([Role.ABOGADO, Role.ASESOR, Role.SUPERADMIN]), uploadDocumento);
+router.post(
+  '/documento/upload',
+  requireRole([Role.ABOGADO, Role.ASESOR, Role.SUPERADMIN]),
+  upload.single('documentFile'),
+  uploadDocumento
+);
 router.post('/documento/descargar', descargarDocumento);
 router.get('/notificaciones/:clienteId', getNotificaciones);
 

--- a/src/services/crmDocument.service.ts
+++ b/src/services/crmDocument.service.ts
@@ -1,0 +1,35 @@
+const CRM_UPLOAD_URL = 'https://gestion.lemornebrabant.com/api/portal/document_upload';
+
+interface CrmUploadResponse {
+  crm_document_id: string;
+}
+
+export const uploadToCrm = async (
+  token: string,
+  documentId: string | number,
+  expedientId: string | number,
+  file: { buffer: Buffer; originalname: string; mimetype: string }
+): Promise<CrmUploadResponse> => {
+  const formData = new FormData();
+  formData.append('document_id', String(documentId));
+  formData.append('expedient_id', String(expedientId));
+  formData.append(
+    'documentFile',
+    new Blob([file.buffer], { type: file.mimetype }),
+    file.originalname
+  );
+
+  const response = await fetch(CRM_UPLOAD_URL, {
+    method: 'POST',
+    headers: {
+      'Customer-Bearer': token,
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error('CRM upload failed');
+  }
+
+  return (await response.json()) as CrmUploadResponse;
+};

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -6,6 +6,11 @@ declare global {
       crmToken?: string;
       userId?: number;
       userRole?: Role;
+      file?: {
+        buffer: Buffer;
+        originalname: string;
+        mimetype: string;
+      };
     }
   }
 }

--- a/src/types/multer.d.ts
+++ b/src/types/multer.d.ts
@@ -1,0 +1,4 @@
+declare module 'multer' {
+  const _tmp: any;
+  export default _tmp;
+}


### PR DESCRIPTION
## Summary
- add CRM upload service and use FormData
- support multer-based uploads in request types
- implement new uploadDocumento logic
- store new CRM IDs in database

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684807bb901883278498dbf0ff634996