### PR TITLE
Fix async controllers and add error handling

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import morgan from 'morgan';
 import routes from './routes';
 import { ipAudit } from './middlewares/ipAudit.middleware';
+import errorHandler from './middlewares/error.middleware';
 
 const app = express();
 
@@ -11,5 +12,6 @@ app.use(morgan('dev'));
 app.use(ipAudit);
 app.use(express.json());
 app.use('/api', routes);
+app.use(errorHandler);
 
 export default app;

--- a/src/controllers/documento.controller.ts
+++ b/src/controllers/documento.controller.ts
@@ -15,7 +15,21 @@ export const uploadDocumento = async (
     };
 
     if (!req.file || !document_id || !expedient_id) {
-      res.status(400).json({ error: 'document_id, expedient_id y archivo requeridos' });
+      res
+        .status(400)
+        .json({ error: 'document_id, expedient_id y archivo requeridos' });
+      return;
+    }
+
+    // Validación opcional de tipo MIME y tamaño
+    if (req.file.size > 10 * 1024 * 1024) {
+      res.status(400).json({ error: 'El archivo excede el tamaño máximo de 10MB' });
+      return;
+    }
+
+    const allowedMime = ['application/pdf', 'image/png', 'image/jpeg'];
+    if (!allowedMime.includes(req.file.mimetype)) {
+      res.status(400).json({ error: 'Tipo de archivo no permitido' });
       return;
     }
 

--- a/src/controllers/example.controller.ts
+++ b/src/controllers/example.controller.ts
@@ -1,5 +1,9 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 
-export const getExample = (_req: Request, res: Response) => {
+export const getExample = (
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void => {
   res.json({ message: 'Ruta /example funcionando correctamente' });
 };

--- a/src/controllers/expediente.controller.ts
+++ b/src/controllers/expediente.controller.ts
@@ -1,21 +1,21 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { crmGet } from '../services/crm.service';
 
-export const getExpedientes = async (req: Request, res: Response) => {
-  try {
-    const data = await crmGet('/expedientes', req.crmToken!);
-    res.json(data);
-  } catch (error) {
-    res.status(500).json({ error: 'Error al obtener expedientes' });
-  }
+export const getExpedientes = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
+  const data = await crmGet('/expedientes', req.crmToken!);
+  res.status(200).json(data);
 };
 
-export const getDocumentos = async (req: Request, res: Response) => {
+export const getDocumentos = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const { expedienteId } = req.params;
-  try {
-    const data = await crmGet(`/documentos/${expedienteId}`, req.crmToken!);
-    res.json(data);
-  } catch (error) {
-    res.status(500).json({ error: 'Error al obtener documentos' });
-  }
+  const data = await crmGet(`/documentos/${expedienteId}`, req.crmToken!);
+  res.status(200).json(data);
 };

--- a/src/controllers/expedientePredefinido.controller.ts
+++ b/src/controllers/expedientePredefinido.controller.ts
@@ -1,23 +1,42 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../utils/prisma';
 
-export const createExpedientePredefinido = async (req: Request, res: Response) => {
+export const createExpedientePredefinido = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const data = await prisma.expedientePredefinido.create({ data: req.body });
-  res.json(data);
+  res.status(201).json(data);
 };
 
-export const listExpedientePredefinido = async (_req: Request, res: Response) => {
+export const listExpedientePredefinido = async (
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const data = await prisma.expedientePredefinido.findMany();
-  res.json(data);
+  res.status(200).json(data);
 };
 
-export const updateExpedientePredefinido = async (req: Request, res: Response) => {
+export const updateExpedientePredefinido = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const { id } = req.params;
-  const data = await prisma.expedientePredefinido.update({ where: { id: parseInt(id, 10) }, data: req.body });
-  res.json(data);
+  const data = await prisma.expedientePredefinido.update({
+    where: { id: parseInt(id, 10) },
+    data: req.body,
+  });
+  res.status(200).json(data);
 };
 
-export const deleteExpedientePredefinido = async (req: Request, res: Response) => {
+export const deleteExpedientePredefinido = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const { id } = req.params;
   await prisma.expedientePredefinido.delete({ where: { id: parseInt(id, 10) } });
   res.status(204).end();

--- a/src/controllers/notificacion.controller.ts
+++ b/src/controllers/notificacion.controller.ts
@@ -1,11 +1,15 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../utils/prisma';
 
-export const getNotificaciones = async (req: Request, res: Response) => {
+export const getNotificaciones = async (
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): Promise<void> => {
   const { clienteId } = req.params;
   const notificaciones = await prisma.notificacionCliente.findMany({
     where: { clienteId: parseInt(clienteId, 10) },
     orderBy: { createdAt: 'desc' },
   });
-  res.json(notificaciones);
+  res.status(200).json(notificaciones);
 };

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const errorHandler = (
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+};
+
+export default errorHandler;
+

--- a/src/routes/example.routes.ts
+++ b/src/routes/example.routes.ts
@@ -1,14 +1,14 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { runPrismaMigrate } from '../utils/migrate';
 
 const router = Router();
 
-router.get('/migrate', async (_req, res) => {
+router.get('/migrate', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const result = await runPrismaMigrate();
     res.status(200).json({ message: 'Migración ejecutada', result });
   } catch (error) {
-    res.status(500).json({ message: 'Error ejecutando migración', error });
+    next(error);
   }
 });
 

--- a/src/routes/expediente.routes.ts
+++ b/src/routes/expediente.routes.ts
@@ -10,7 +10,18 @@ import { catchAsync } from '../utils/catchAsync'; // 👈 añadimos nuestro wrap
 
 const router = Router();
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['application/pdf', 'image/png', 'image/jpeg'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Tipo de archivo no permitido'));
+    }
+  },
+});
 
 // Middleware global para todas las rutas
 router.use(requireSession, attachRole);

--- a/src/routes/expedientePredefinido.routes.ts
+++ b/src/routes/expedientePredefinido.routes.ts
@@ -8,14 +8,15 @@ import {
 import { requireSession } from '../middlewares/session.middleware';
 import { attachRole, requireRole } from '../middlewares/role.middleware';
 import { Role } from '@prisma/client';
+import { catchAsync } from '../utils/catchAsync';
 
 const router = Router();
 
 router.use(requireSession, attachRole, requireRole([Role.SUPERADMIN]));
 
-router.post('/', createExpedientePredefinido);
-router.get('/', listExpedientePredefinido);
-router.put('/:id', updateExpedientePredefinido);
-router.delete('/:id', deleteExpedientePredefinido);
+router.post('/', catchAsync(createExpedientePredefinido));
+router.get('/', catchAsync(listExpedientePredefinido));
+router.put('/:id', catchAsync(updateExpedientePredefinido));
+router.delete('/:id', catchAsync(deleteExpedientePredefinido));
 
 export default router;

--- a/src/routes/migrate.routes.ts
+++ b/src/routes/migrate.routes.ts
@@ -1,16 +1,16 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
 const router = Router();
 const execAsync = promisify(exec);
 
-router.get('/migrate', async (_req, res) => {
+router.get('/migrate', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const { stdout } = await execAsync('npx prisma migrate deploy');
     res.status(200).json({ message: 'Migración ejecutada', log: stdout });
   } catch (error) {
-    res.status(500).json({ message: 'Error al ejecutar la migración', error });
+    next(error);
   }
 });
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -10,6 +10,7 @@ declare global {
         buffer: Buffer;
         originalname: string;
         mimetype: string;
+        size: number;
       };
     }
   }

--- a/src/utils/catchAsync.ts
+++ b/src/utils/catchAsync.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+export type AsyncHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<void>;
+
+export const catchAsync = (fn: AsyncHandler) => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+};
+
+export default catchAsync;
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "types": ["node"],
+    "typeRoots": ["./src/types", "./node_modules/@types"],
+    "resolveJsonModule": true
   }
 }
 


### PR DESCRIPTION
## Summary
- add global async error wrapper `catchAsync`
- add centralized error handler middleware
- validate uploads in document controller
- update controllers to use proper async signatures
- secure routes with `catchAsync`
- improve multer config and tsconfig

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6849393ca4f88327bc1ca2cdee7a906b