### PR TITLE
Fix async controller patterns and middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import morgan from 'morgan';
 import routes from './routes';
 import { ipAudit } from './middlewares/ipAudit.middleware';
-import errorHandler from './middlewares/error.middleware';
+import { errorHandler } from './middlewares/error.middleware';
 
 const app = express();
 

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,14 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 
-export const errorHandler = (
+export function errorHandler(
   err: any,
-  _req: Request,
+  req: Request,
   res: Response,
-  _next: NextFunction
-): void => {
+  next: NextFunction
+) {
   console.error(err);
-  res.status(500).json({ error: 'Internal Server Error' });
-};
-
-export default errorHandler;
+  res.status(500).json({ error: 'Error interno del servidor' });
+}
 

--- a/src/middlewares/role.middleware.ts
+++ b/src/middlewares/role.middleware.ts
@@ -10,11 +10,13 @@ export const attachRole = async (
   try {
     const userId = req.userId;
     if (!userId) {
-      return res.status(401).json({ error: 'Usuario no identificado' });
+      res.status(401).json({ error: 'Usuario no identificado' });
+      return;
     }
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
-      return res.status(401).json({ error: 'Usuario no encontrado' });
+      res.status(401).json({ error: 'Usuario no encontrado' });
+      return;
     }
     req.userRole = user.role;
     next();
@@ -27,7 +29,8 @@ export const requireRole = (roles: Role[]) => {
   return (req: Request, res: Response, next: NextFunction) => {
     const role = req.userRole;
     if (!role || !roles.includes(role)) {
-      return res.status(403).json({ error: 'Permiso denegado' });
+      res.status(403).json({ error: 'Permiso denegado' });
+      return;
     }
     next();
   };

--- a/src/middlewares/session.middleware.ts
+++ b/src/middlewares/session.middleware.ts
@@ -9,7 +9,8 @@ export const requireSession = async (
   try {
     const token = req.headers['x-session-token'];
     if (!token || typeof token !== 'string') {
-      return res.status(401).json({ error: 'Token de sesión requerido' });
+      res.status(401).json({ error: 'Token de sesión requerido' });
+      return;
     }
 
     const session = await prisma.userSession.findUnique({
@@ -17,7 +18,8 @@ export const requireSession = async (
     });
 
     if (!session) {
-      return res.status(401).json({ error: 'Sesión inválida' });
+      res.status(401).json({ error: 'Sesión inválida' });
+      return;
     }
 
     req.crmToken = session.crmToken;

--- a/src/routes/example.routes.ts
+++ b/src/routes/example.routes.ts
@@ -1,15 +1,15 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { catchAsync } from '../utils/catchAsync';
 import { runPrismaMigrate } from '../utils/migrate';
 
 const router = Router();
 
-router.get('/migrate', async (_req: Request, res: Response, next: NextFunction) => {
-  try {
+router.get(
+  '/migrate',
+  catchAsync(async (_req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const result = await runPrismaMigrate();
     res.status(200).json({ message: 'Migración ejecutada', result });
-  } catch (error) {
-    next(error);
-  }
-});
+  })
+);
 
 export default router;

--- a/src/routes/migrate.routes.ts
+++ b/src/routes/migrate.routes.ts
@@ -1,17 +1,17 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { catchAsync } from '../utils/catchAsync';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
 const router = Router();
 const execAsync = promisify(exec);
 
-router.get('/migrate', async (_req: Request, res: Response, next: NextFunction) => {
-  try {
+router.get(
+  '/migrate',
+  catchAsync(async (_req: Request, res: Response, _next: NextFunction): Promise<void> => {
     const { stdout } = await execAsync('npx prisma migrate deploy');
     res.status(200).json({ message: 'Migración ejecutada', log: stdout });
-  } catch (error) {
-    next(error);
-  }
-});
+  })
+);
 
 export default router;

--- a/src/utils/catchAsync.ts
+++ b/src/utils/catchAsync.ts
@@ -1,16 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 
-export type AsyncHandler = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => Promise<void>;
+type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
 
-export const catchAsync = (fn: AsyncHandler) => {
-  return (req: Request, res: Response, next: NextFunction): void => {
+export function catchAsync(fn: AsyncHandler) {
+  return function (req: Request, res: Response, next: NextFunction) {
     fn(req, res, next).catch(next);
   };
-};
-
-export default catchAsync;
+}
 


### PR DESCRIPTION
## Summary
- update catchAsync util to match spec
- implement new global error handler and use named import
- sanitize middlewares to return void instead of Response
- wrap remaining routes with catchAsync

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm run dev` *(fails: ts-node-dev not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493cc7b4408327b407354f3527cb3a