### PR TITLE
Fix typings and login validation

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -8,6 +8,11 @@ export const loginConCRM = async (
 ): Promise<void> => {
   const { email, password } = req.body;
 
+  if (!email || !password) {
+    res.status(400).json({ error: 'Email y contraseña son requeridos.' });
+    return;
+  }
+
   try {
     const response = await axios.post(
       'https://gestion.lemornebrabant.com/api/portal/login',

--- a/backend/src/middlewares/role.middleware.ts
+++ b/backend/src/middlewares/role.middleware.ts
@@ -19,6 +19,7 @@ export const attachRole = async (
       return;
     }
     req.userRole = user.role;
+    req.user = user;
     next();
   } catch (error) {
     next(error);

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import { Role } from '@prisma/client';
+import { Role, User } from '@prisma/client';
 
 declare global {
   namespace Express {
@@ -6,6 +6,7 @@ declare global {
       crmToken?: string;
       userId?: number;
       userRole?: Role;
+      user?: User;
       file?: {
         buffer: Buffer;
         originalname: string;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,7 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": ["node"],
-    "typeRoots": ["./src/types", "./node_modules/@types"],
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types", "./src/types"]
   }


### PR DESCRIPTION
## Summary
- extend Express request type with `user` property
- ensure tsconfig includes typeRoots
- validate email and password on login
- store entire User in role middleware for downstream usage

## Testing
- `npm run dev` *(fails: ts-node-dev not found)*

------
https://chatgpt.com/codex/tasks/task_e_684946f333b0832787ae8c8f5ef479f0