### PR TITLE
Fix Express Request typing and middlewares

### DIFF
--- a/backend/src/middlewares/role.middleware.ts
+++ b/backend/src/middlewares/role.middleware.ts
@@ -1,18 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import prisma from '../utils/prisma';
-
-// Tipo extendido explícito
-type TypedRequest = Request & {
-  userId?: number;
-  userRole?: string;
-  user?: any;
-};
+import { Role } from '@prisma/client';
 
 export const attachRole = async (
-  req: TypedRequest,
+  req: Request,
   res: Response,
   next: NextFunction
-) => {
+): Promise<void> => {
   try {
     const userId = req.userId;
 
@@ -37,8 +31,8 @@ export const attachRole = async (
   }
 };
 
-export const requireRole = (roles: string[]) => {
-  return (req: TypedRequest, res: Response, next: NextFunction) => {
+export const requireRole = (roles: Role[]) => {
+  return (req: Request, res: Response, next: NextFunction): void => {
     const role = req.userRole;
 
     if (!role || !roles.includes(role)) {

--- a/backend/src/middlewares/session.middleware.ts
+++ b/backend/src/middlewares/session.middleware.ts
@@ -5,7 +5,7 @@ export const requireSession = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
+) : Promise<void> => {
   try {
     const token = req.headers['x-session-token'];
     if (!token || typeof token !== 'string') {

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,12 +1,10 @@
 import { User, Role } from '@prisma/client';
 
-declare global {
-  namespace Express {
-    interface Request {
-      crmToken?: string;
-      userId?: number;
-      user?: User;
-      userRole?: Role;
-    }
+declare namespace Express {
+  export interface Request {
+    crmToken?: string;
+    userId?: number;
+    userRole?: Role;
+    user?: User;
   }
 }


### PR DESCRIPTION
## Summary
- declare custom Express Request fields
- update middleware typing to use global Express Request
- ensure session middleware returns a promise

## Testing
- `npx tsc` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm run dev` *(fails: ts-node-dev not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b812c0c8327a82afa460bbbd710